### PR TITLE
Added "Other" authorization scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Goland IDE
+.idea/
+
+out/
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/main.go
+++ b/main.go
@@ -132,9 +132,13 @@ func New(config ...Config) fiber.Handler {
 func keyFromHeader(header string, authScheme string) func(c *fiber.Ctx) (string, error) {
 	return func(c *fiber.Ctx) (string, error) {
 		auth := c.Get(header)
-		l := len(authScheme)
-		if len(auth) > l+1 && auth[:l] == authScheme {
-			return auth[l+1:], nil
+		if strings.EqualFold(authScheme, "Other") {
+			return auth, nil
+		} else {
+			l := len(authScheme)
+			if len(auth) > l+1 && auth[:l] == authScheme {
+				return auth[l+1:], nil
+			}
 		}
 		return "", errMissingOrMalformedAPIKey
 	}


### PR DESCRIPTION
Presently **keyauth** does not authorize requests with custom authorization header value (e.g **X-API-Key d777fa53-5b40-4ad8-9bb1-7ecde3fbde8a**) . 

Example:

```
package main

import (
	"github.com/gofiber/fiber/v2"
	"github.com/gofiber/keyauth/v2"
	"log"
)

func main() {

	app := fiber.New()

	isAuthorized := func(ctx *fiber.Ctx, s string) (bool, error) {
		if s == "d777fa53-5b40-4ad8-9bb1-7ecde3fbde8a" {
			return true, nil
		}
		return false, nil
	}

	app.Use(keyauth.New(keyauth.Config{
		KeyLookup: "header:X-API-Key",
		Validator: isAuthorized,
	}))

	app.Post("/keyauth", func(ctx *fiber.Ctx) error {
		return ctx.Send([]byte("Passed!"))
	})

	log.Fatal(app.Listen(":3000"))
}

```

With this pull request, the above can be amended thus

```
	app.Use(keyauth.New(keyauth.Config{
		KeyLookup: "header:X-API-Key",
		Validator: isAuthorized,
		AuthScheme: "Other",
	}))
```

and the authorization will succeed.